### PR TITLE
Fix not seeing all contexts after kubechc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,6 @@ $ kubechn monitoring
 - This tools has been tested with `bash 4.4` only. However it should work with other shells like `zsh`.
 - It's recommended to use this tool with [kube-ps1](https://github.com/jonmosco/kube-ps1) so current cluster is more visible.
 - It's still recommended to have [kubectx/kubens](https://github.com/ahmetb/kubectx) to manage contexts/namespaces globally.
-- Once `kubech` is used to change context/namespace, it's not possible to change context/namespace again in the same shell.
-  Open a new shell/terminal to be able to list and change to all contexts/namespaces again.
 
 ## To-do
 - Add autocomplete support for `zsh` (if you have an experience with zsh feel free to make a PR).

--- a/kubech
+++ b/kubech
@@ -27,6 +27,15 @@ EOF
 
 
 #
+# Remember original kubeconfig.
+if [[ $KUBECONFIG ]]; then
+  kube_config_org=${KUBECONFIG}
+else
+  kube_config_org="${HOME}/.kube/config"
+fi
+
+
+#
 # General.
 if ! [[ -d ${kube_config_dir} ]]; then
     mkdir -p ${kube_config_dir}
@@ -63,7 +72,7 @@ kubechc () {
         export KUBECONFIG="${kube_config_dir}/${kube_config_file}"
         kubectl config use-context ${kube_context}
     else
-        kubectl config get-contexts --no-headers=true -o name
+        kubectl config get-contexts --kubeconfig=${kube_config_org} --no-headers=true -o name
     fi
 }
 

--- a/kubech
+++ b/kubech
@@ -27,34 +27,35 @@ EOF
 
 
 #
-# Remember original kubeconfig.
-if [[ $KUBECONFIG ]]; then
-  kube_config_org=${KUBECONFIG}
+# Store original path of kubeconfig.
+if [[ -n "${KUBECONFIG}" ]]; then
+    kube_config_file_orig="${KUBECONFIG}"
 else
-  kube_config_org="${HOME}/.kube/config"
+    kube_config_file_orig="${HOME}/.kube/config"
 fi
 
 
 #
 # General.
-if ! [[ -d ${kube_config_dir} ]]; then
-    mkdir -p ${kube_config_dir}
+if ! [[ -d "${kube_config_dir}" ]]; then
+    mkdir -p "${kube_config_dir}"
 fi
 
 
 #
 # Generate kubectl config for a single context.
 _kubechg () {
-    kube_context=${1}
-    kube_namespace=${2:-default}
+    kube_context="${1}"
+    kube_namespace="${2:-default}"
     kube_config_file="${kube_context}-${kube_namespace}"
     KUBECONFIG="${HOME}/.kube/config"
 
-    kubectl config view            \
-        --minify                   \
-        --flatten                  \
-        --context=${kube_context}  |
-        sed -r 's/((\s+)cluster: .+)/\1\n\2namespace: '${kube_namespace}'/g' > ${kube_config_dir}/${kube_config_file}
+    kubectl config view             \
+        --minify                    \
+        --flatten                   \
+        --context="${kube_context}" |
+        sed -r 's/((\s+)cluster: .+)/\1\n\2namespace: '"${kube_namespace}"'/g' > \
+        "${kube_config_dir}/${kube_config_file}"
 
     chmod 600 "${kube_config_dir}/${kube_config_file}"
 }
@@ -63,16 +64,16 @@ _kubechg () {
 #
 # Change kubectl context.
 kubechc () {
-    kube_context=${1}
-    kube_namespace=${2:-default}
+    kube_context="${1}"
+    kube_namespace="${2:-default}"
     kube_config_file="${kube_context}-${kube_namespace}"
 
-    if [[ -n ${kube_context} ]]; then
-        _kubechg ${kube_context} ${kube_namespace}
+    if [[ -n "${kube_context}" ]]; then
+        _kubechg "${kube_context}" "${kube_namespace}"
         export KUBECONFIG="${kube_config_dir}/${kube_config_file}"
-        kubectl config use-context ${kube_context}
+        kubectl config use-context "${kube_context}"
     else
-        kubectl config get-contexts --kubeconfig=${kube_config_org} --no-headers=true -o name
+        kubectl config get-contexts --kubeconfig="${kube_config_file_orig}" --no-headers=true -o name
     fi
 }
 
@@ -81,13 +82,13 @@ alias kchc='kubechc'
 #
 # Change kubectl namespace
 kubechn () {
-    kube_namespace=${1:-default}
+    kube_namespace="${1:-default}"
     kube_namespace_all=$(kubectl get namespaces -o=jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
 
     if [[ -n ${1} ]]; then
         # Only switch namespace if it exists.
-        if [[ $(echo "${kube_namespace_all}" | egrep "^${kube_namespace}$") ]]; then
-            kubechc $(kubectl config current-context) ${kube_namespace}
+        if echo "${kube_namespace_all}" | grep -qE "^${kube_namespace}$"; then
+            kubechc "$(kubectl config current-context)" "${kube_namespace}"
             echo "Switched to namespace \"${kube_namespace}\""
         else
             echo "The namespace \"${kube_namespace}\" doesn't exist"


### PR DESCRIPTION
At first, thank you for sharing this simple but useful tool.
I have found a problem in kubech and have written the code to fix it. I would be happy if you could merge it.

### The issue:

After executing the kubechc command, if you execute the kubechc command again without options, only the current context will be displayed. 

![image](https://user-images.githubusercontent.com/43510508/102677660-c6e34a00-41e6-11eb-92e6-54695105818f.png)

### Expected behavior:

All context will be displayed also after the execution of kubechc.

![image](https://user-images.githubusercontent.com/43510508/102677756-2a6d7780-41e7-11eb-95e7-590d8a1ae884.png)

Thanks