### PR TITLE
use tr to output the list of files

### DIFF
--- a/kubech
+++ b/kubech
@@ -54,7 +54,7 @@ chmod 744 "${KUBECONFIG_SRC_DIR}" "${KUBECONFIG_DEST_DIR}"
 # Handeling Kube config files.
 _kubeconfig_files () {
     if [ -d "${KUBECONFIG_SRC_DIR}" ]; then
-        KUBECONFIG_FILES="$(find "${KUBECONFIG_SRC_DIR}" -type f -print0 | tr '/n' ':')"
+        KUBECONFIG_FILES="$(find "${KUBECONFIG_SRC_DIR}" -type f -print | tr '\n' ':')"
     fi
     echo "${KUBECONFIG_FILES}${KUBECONFIG_ORIG}"
 }

--- a/kubech
+++ b/kubech
@@ -54,7 +54,7 @@ chmod 744 "${KUBECONFIG_SRC_DIR}" "${KUBECONFIG_DEST_DIR}"
 # Handeling Kube config files.
 _kubeconfig_files () {
     if [ -d "${KUBECONFIG_SRC_DIR}" ]; then
-        KUBECONFIG_FILES="$(find "${KUBECONFIG_SRC_DIR}" -type f -printf '%p:')"
+        KUBECONFIG_FILES="$(find "${KUBECONFIG_SRC_DIR}" -type f -print0 | tr '/n' ':')"
     fi
     echo "${KUBECONFIG_FILES}${KUBECONFIG_ORIG}"
 }


### PR DESCRIPTION
On https://github.com/aabouzaid/kubech/issues/7 it's reported that when using MacOs' default `find`, it makes `kubechc` to crash. 

This PR aims at leveraging `tr` command instead to print the `:` separated list of files instead of relying on a flag only available in specific versions of `find`.

Eventho it's not a very scientific test, it works on my MacOS Monterrey mac. There's no reason for it not to work in any widespread linux distribution. 