### PR TITLE
Unquote asterisk so the shell can expand it

### DIFF
--- a/kubech
+++ b/kubech
@@ -151,8 +151,8 @@ alias kchu='kubechu'
 #
 # Remove auto-generated kubeconf files from kubech dist dir.
 kubechr () {
-    ls "${KUBECONFIG_DEST_DIR}/*.yaml" &&
-    rm "${KUBECONFIG_DEST_DIR}/*.yaml"
+    ls "${KUBECONFIG_DEST_DIR}"/*.yaml &&
+    rm "${KUBECONFIG_DEST_DIR}"/*.yaml
 }
 
 alias kchr='kubechr'


### PR DESCRIPTION
When running `kubechr` I was getting file not found because it was trying to `ls` the literal file:
  `/home/user/.kube/config.dest.d/*.yaml`
Moving the asterisk outside the quotes allows the shell to expand it and then properly list and remove the files.